### PR TITLE
Fix Email template HTML tags

### DIFF
--- a/pykeg/web/templates/notification/email_keg_ended.html
+++ b/pykeg/web/templates/notification/email_keg_ended.html
@@ -1,6 +1,6 @@
 {% extends 'notification/email_base.html' %}
 
-{% block subject %}[{{ site_name }}] Keg ended: Keg {{ keg.id }}: {{ keg.type }}{% endblock %}
+{% block subject %}[{{ site_name|safe }}] Keg ended: Keg {{ keg.id }}: {{ keg.type }}{% endblock %}
 
 {% block body_plain %}
 Keg {{ keg.id }} of {{ keg.type }} was just finished on {{ site_name }}.

--- a/pykeg/web/templates/notification/email_keg_tapped.html
+++ b/pykeg/web/templates/notification/email_keg_tapped.html
@@ -1,6 +1,6 @@
 {% extends 'notification/email_base.html' %}
 
-{% block subject %}[{{ site_name }}] New keg tapped: Keg {{ keg.id }}: {{ keg.type }}{% endblock %}
+{% block subject %}[{{ site_name|safe }}] New keg tapped: Keg {{ keg.id }}: {{ keg.type }}{% endblock %}
 
 {% block body_plain %}
 A new keg of {{ keg.type }} was just tapped on {{ site_name }}!

--- a/pykeg/web/templates/notification/email_keg_volume_low.html
+++ b/pykeg/web/templates/notification/email_keg_volume_low.html
@@ -1,6 +1,6 @@
 {% extends 'notification/email_base.html' %}
 
-{% block subject %}[{{ site_name }}] Volume low on keg {{ keg.id }} ({{ keg.type }}){% endblock %}
+{% block subject %}[{{ site_name|safe }}] Volume low on keg {{ keg.id }} ({{ keg.type }}){% endblock %}
 
 {% block body_plain %}
 Keg {{ keg.id }} ({{ keg.type }}) is {{ keg.percent_full}}% full.

--- a/pykeg/web/templates/notification/email_session_started.html
+++ b/pykeg/web/templates/notification/email_session_started.html
@@ -1,6 +1,6 @@
 {% extends 'notification/email_base.html' %}
 
-{% block subject %}[{{ site_name }}] A new session (session {{ session.id }}) has started.{% endblock %}
+{% block subject %}[{{ site_name|safe }}] A new session (session {{ session.id }}) has started.{% endblock %}
 
 {% block body_plain %}
 {% if not drink.is_guest_pour %}A new session was just kicked off by {{ drink.user }} on {{ site_name }}.

--- a/pykeg/web/templates/notification/email_test.html
+++ b/pykeg/web/templates/notification/email_test.html
@@ -1,6 +1,6 @@
 {% extends 'notification/email_base.html' %}
 
-{% block subject %}[{{ site_name }}] Test E-mail{% endblock %}
+{% block subject %}[{{ site_name|safe }}] Test E-mail{% endblock %}
 
 {% block body_plain %}
 This is a test e-mail from {{ site_name }}.


### PR DESCRIPTION
Add the "safe" template tag to the site name in the email templates to resolve HTML formatting issues.