### PR TITLE
Resolve issue with django parsing unicode character

### DIFF
--- a/pykeg/web/kegadmin/templates/kegadmin/token_detail.html
+++ b/pykeg/web/kegadmin/templates/kegadmin/token_detail.html
@@ -10,7 +10,7 @@
 <div id="deleteModal" class="modal hide fade" tabindex="-1"
     role="dialog" aria-labelledby="deleteDialogLabel" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">x</button>
         <h3 id="deleteDialogLabel">Delete Token: {{ token.token_value }}?</h3>
     </div>
     <div class="modal-body">


### PR DESCRIPTION
It seems Python is having trouble parsing the unicode 'x' character used for the close button on the Delete Token Modal pop-up. I've updated to just switch to the regular 'X' character.