### PR TITLE
Add default user option for non-authenticated pours

### DIFF
--- a/deploy/travis/local_settings.py
+++ b/deploy/travis/local_settings.py
@@ -11,6 +11,8 @@ DATABASES = {'default': {'ENGINE': 'django.db.backends.mysql', 'NAME': 'kegbot_t
 
 KEGBOT_ROOT = HOME + '/kegbot-data'
 
+KEGBOT_DEFAULT_USERNAME = 'guest'
+
 MEDIA_ROOT = KEGBOT_ROOT  + '/media'
 
 STATIC_ROOT = KEGBOT_ROOT + '/static'

--- a/pykeg/backend/backends.py
+++ b/pykeg/backend/backends.py
@@ -191,7 +191,13 @@ class KegbotBackend(object):
         if username:
             user = self.get_user(username)
         else:
-            user = models.User.objects.get(username='guest')
+            default_user = getattr(settings, 'KEGBOT_DEFAULT_USERNAME', 'guest')
+            try:
+                user = models.User.objects.get(username=default_user)
+            except:
+                #protect if user enters incorrect username in Settings file
+                user = models.User.objects.get(username='guest')
+
 
         if not pour_time:
             pour_time = timezone.now()


### PR DESCRIPTION
I'm the primary drinker for my Kegbot, so I added the ability to default all pours to my username instead of "Guest".