### PR TITLE
Improve image serving performance

### DIFF
--- a/pykeg/web/kegadmin/templates/kegadmin/beer_type_detail.html
+++ b/pykeg/web/kegadmin/templates/kegadmin/beer_type_detail.html
@@ -12,7 +12,7 @@
 {% if beer_type.picture %}
 <div class="row-fluid">
 <div class="span10">
-<p><img src="{{beer_type.picture.resized.url}}"/></p>
+<p><img src="{{beer_type.picture.thumbnail_png.url}}"/></p>
 </div>
 </div>
 {% endif %}

--- a/pykeg/web/kegweb/templates/kegweb/fullscreen.html
+++ b/pykeg/web/kegweb/templates/kegweb/fullscreen.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}lib/slick/slick.css" media="screen" />
 <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}css/bootstrap-cyborg.css" media="screen" />
 <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}css/fullscreen.css" media="screen" />
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous">
 
 <style>
 
@@ -48,7 +49,7 @@ body {
    bottom:0;
    width:100%;
    height:30px;   /* Height of the footer */
-   font-size:8px;
+   font-size:14px;
    text-align:center;
 }
 
@@ -151,7 +152,7 @@ img.taplist-foot-logos {
 	<div id="userauth" class="flex-container auth-user"></div>
 
     <div id="footer">
-        <a href="/" style="color:#888888">Home</a>
+        <a href="/" style="color:#888888"><i class="fas fa-beer"></i></a>
     </div>
 
   </div> <!-- /container-fluid -->

--- a/pykeg/web/kegweb/templates/kegweb/fullscreen.html
+++ b/pykeg/web/kegweb/templates/kegweb/fullscreen.html
@@ -106,7 +106,7 @@ img.taplist-foot-logos {
             <div class="span2">
               <center>
               {% if keg.type.picture %}
-                <img class="tap-snapshot-image" src="{{ keg.type.picture.resized_png.url }}">
+                <img class="tap-snapshot-image" src="{{ keg.type.picture.thumbnail_png.url }}">
               {% else %}
                 <img class="tap-snapshot-image" src="{{ STATIC_URL }}images/kegbot-unknown-square.png">
               {% endif %}

--- a/pykeg/web/kegweb/templates/kegweb/includes/tap_snapshot.html
+++ b/pykeg/web/kegweb/templates/kegweb/includes/tap_snapshot.html
@@ -52,7 +52,7 @@
       <div class="span4">
         <div style="border: 1px solid #ccc;">
           <a href="{{ keg_url }}">
-            <img src="{{ keg.type.picture.resized.url }}"/>
+            <img src="{{ keg.type.picture.thumbnail.url }}"/>
           </a>
         </div>
       </div>

--- a/pykeg/web/kegweb/templates/kegweb/includes/timeline_event.html
+++ b/pykeg/web/kegweb/templates/kegweb/includes/timeline_event.html
@@ -22,10 +22,10 @@
     {% if pic %}
       <p></p>
       <a class="gallery-image" rel="gallery-{{ gallery_id }}"
-          href="{{ pic.resized.url }}"
+          href="{{ pic.thumbnail.url }}"
           title="{% drinker_name event.user nolink %} pouring drink {{ event.drink.id }}">
-        <img class="lazy" data-original="{{ pic.resized.url }}" width="1024" height="1024"/>
-        <noscript><img src="{{ pic.resized.url }}" width="1024" height="1024"/></noscript>
+        <img class="lazy" data-original="{{ pic.thumbnail.url }}" width="1024" height="1024"/>
+        <noscript><img src="{{ pic.thumbnail.url }}" width="1024" height="1024"/></noscript>
       </a>
     {% endif %}
     {% endwith %}

--- a/pykeg/web/kegweb/templates/kegweb/keg-snapshot.html
+++ b/pykeg/web/kegweb/templates/kegweb/keg-snapshot.html
@@ -7,7 +7,7 @@
     <div class="span3">
       <a href="{{ keg_url }}">
       {% if keg.type.picture %}
-        <img class="tap-snapshot-image" src="{{ keg.type.picture.resized.url }}">
+        <img class="tap-snapshot-image" src="{{ keg.type.picture.thumbnail.url }}">
       {% else %}
         <img class="tap-snapshot-image" src="{{ STATIC_URL }}images/kegbot-unknown-square.png">
       {% endif %}

--- a/pykeg/web/kegweb/templates/kegweb/mugshot_box.html
+++ b/pykeg/web/kegweb/templates/kegweb/mugshot_box.html
@@ -12,7 +12,7 @@
       style="width:100%;"
     {% endif %}
 {% if user and user.mugshot %}
-      src="{{ user.mugshot.resized.url }}"
+      src="{{ user.mugshot.thumbnail.url }}"
 {% else %}
       src="{{ STATIC_URL }}images/unknown-drinker.png"
 {% endif %}


### PR DESCRIPTION
A Google Site audit flagged that the images being served from the web interface were the full size images rather than web-optimized pictures. I've updated the relevant screens to return the minimized thumbnail version of images to improve performance.

This also includes a minor cosmetic update to the Fullscreen View "Home" button.